### PR TITLE
Release v1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,15 @@ Current support status:
 
 > Soft launch: macOS is supported today; Windows validation is in progress.
 
-**Recommended — install through your AI client:**
+**TL;DR:** paste the install prompt into your AI client, answer "Which folder should I initialize?", and let Augur build itself. The dashboard comes up at [localhost:3000](http://localhost:3000).
+
+### Fastest — through your AI client (recommended)
 
 1. Open [`project-brain/capabilities/skills/onboard/install.md`](project-brain/capabilities/skills/onboard/install.md) and paste its prompt into Claude Code, Codex CLI, Gemini CLI, Cursor, or another supported client.
 2. Answer the first question — **"Which folder should I initialize?"**
-3. The agent runs `uv run aug onboard run` (installs dependencies, builds the dashboard, wires MCP, seeds a local brain, verifies the system), then `uv run aug init --project <folder>`. The dashboard comes up at [localhost:3000](http://localhost:3000).
+3. The agent runs `uv run aug onboard run` (installs dependencies, builds the dashboard, wires MCP, seeds a local brain, verifies the system), then `uv run aug init --project <folder>`.
 
-**Shell install — for contributors who want the repo-first workspace:**
+### Manual — shell (repo-first workspace)
 
 ```bash
 git clone https://github.com/augur-os/augur-os.git
@@ -48,7 +50,18 @@ uv run aug onboard run
 
 **Requirements:** Python 3.11+, Node 22+, [uv](https://docs.astral.sh/uv/), and pnpm (enabled via corepack).
 
-The full first-run walkthrough and the first-brain workflow are in [Working Locally](#working-locally) below.
+### Verify it worked
+
+1. Open the dashboard at [localhost:3000](http://localhost:3000) — it should load to an interactive Browse surface.
+2. Run a first `/ask` (or `/discover`) in your AI client to confirm the brain answers.
+
+The full first-run walkthrough and the first-brain workflow are in [Getting Started](docs/getting-started.md) and [Working Locally](#working-locally) below.
+
+## Vibe coding with Augur
+
+Augur gives your AI client durable context — vault, wiki, memory — plus reusable skills and MCP tools, so you can build fast by directing the agent instead of wiring each project by hand. The same brain rides across Claude Code, Codex, Gemini, Cursor, and Copilot, so switching clients doesn't reset your setup.
+
+> ⚠️ **Keep a human in the loop.** Review and test AI-generated code and output before you rely on it. Augur is pre-1.0 soft launch — expect rough edges, pin versions, and mind secrets and private data. See [docs/vibe-coding.md](docs/vibe-coding.md) for the safe loop and the full caveats.
 
 ## What is Augur?
 

--- a/apps/dashboard/app/api/cli/cli-config.ts
+++ b/apps/dashboard/app/api/cli/cli-config.ts
@@ -25,6 +25,13 @@ export const AUGUR_ROOT =
 // with the legacy flat vault/ai path kept readable during migration.
 const CLI_AGENTS_PATH_CANDIDATES = [
   path.join(AUGUR_VAULT_CONFIG_DIR, "ai", "cli_agents.yaml"),
+  // Explicit _augur/config candidate. AUGUR_VAULT_CONFIG_DIR is resolved ONCE at
+  // module load via existsSync, so if the server booted before the vault's
+  // _augur/config existed (e.g. mid vault-sync during `aug dev build`), it cached
+  // the legacy path and EVERY CLI chat failed with "Unknown CLI: <cli>" until the
+  // next restart. resolveCliAgentsPath() re-checks each candidate at call time, so
+  // this finds the real file regardless of that cached choice.
+  path.join(AUGUR_VAULT_DIR, "_augur", "config", "ai", "cli_agents.yaml"),
   path.join(AUGUR_VAULT_DIR, "config", "ai", "cli_agents.yaml"),
   path.join(AUGUR_VAULT_DIR, "ai", "cli_agents.yaml"),
 ];

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -115,4 +115,5 @@ Day-to-day, you live in the **dashboard browse page** (`/browse`) and your **AI 
 - Discover tools: `aug discover`
 - Search your knowledge: `aug unified-search --query "your topic"`
 - Create a skill: See [creating-skills.md](creating-skills.md)
+- Build by directing your AI client: See [vibe-coding.md](vibe-coding.md)
 - Explore the architecture: See [architecture-overview.md](architecture-overview.md)

--- a/docs/vibe-coding.md
+++ b/docs/vibe-coding.md
@@ -1,0 +1,37 @@
+# Vibe coding with Augur
+
+> If you've never seen Augur before, read [what-is-augur.md](./what-is-augur.md) first — it explains what Augur is and isn't in five minutes.
+
+## What "vibe coding" means here
+
+Vibe coding is building primarily by directing an AI client — you describe intent, the agent writes and runs the code, and you steer rather than type every line. It is fast and fluid, and it works best when the agent has durable context to draw on and a human reviewing what comes back.
+
+## How Augur helps
+
+Augur is the local harness underneath your AI client, so the agent isn't starting cold each session:
+
+- **Durable context** — your vault, compiled wiki, and memory persist across sessions and projects, so the agent already knows your setup, decisions, and prior work.
+- **Reusable skills** — expertise you write once in `project-brain/capabilities/skills/` is available as named workflows the agent can invoke instead of improvising.
+- **MCP tools** — atomic operations (search, ingest, extract, save) run through one local MCP server, so the agent acts on real local state rather than guessing.
+- **One brain across clients** — the same effective context works in Claude Code, Codex, Gemini, Cursor, and Copilot. Switch clients for the job at hand without rebuilding your setup.
+
+## A safe loop
+
+1. **Ingest context** — bring the relevant documents, notes, and prior work into the brain so the agent retrieves from real material.
+2. **Ask / build** — direct the agent to answer, draft, or implement.
+3. **Review** — read and test what comes back before you depend on it. This step is not optional.
+4. **Keep what's good** — persist the useful output (a prompt, a skill, a note, a decision) so the next session compounds on it.
+
+## ⚠️ Warning
+
+- **AI-generated code and output must be reviewed and tested.** The agent can be confidently wrong. Treat its output as a draft from a fast but fallible collaborator, not a finished answer.
+- **Augur is pre-1.0 soft launch.** Expect rough edges and breaking changes. Pin versions and check the [Roadmap](../ROADMAP.md) before depending on anything.
+- **Mind secrets and private data.** Be deliberate about what context you feed the agent and which client (and model) processes it.
+- **No guarantees.** Augur makes no guarantee of correctness or security. You own the review.
+
+## Links
+
+- [Quick Start](../README.md#quick-start)
+- [Getting Started](./getting-started.md)
+- [What is Augur?](./what-is-augur.md)
+- [Roadmap](../ROADMAP.md)

--- a/docs/what-is-augur.md
+++ b/docs/what-is-augur.md
@@ -143,3 +143,4 @@ The same project, opened in Codex tomorrow, gets the same behavior — because A
 - [docs/architecture-overview.md](./architecture-overview.md) — The Harness in detail (5 layers, runtime substrate, the Inversion)
 - [docs/architecture-mcp-gateway.md](./architecture-mcp-gateway.md) — The Connection Layer (how Augur reaches every client)
 - [docs/getting-started.md](./getting-started.md) — first install, first session
+- [docs/vibe-coding.md](./vibe-coding.md) — building by directing your AI client, and the safe loop

--- a/src/mcp/augur_framework/tools/infrastructure/browse/index.py
+++ b/src/mcp/augur_framework/tools/infrastructure/browse/index.py
@@ -139,6 +139,35 @@ __all__ = [
 _FILENAME_ID_COLLISION_CATEGORIES = {"documents", "scripts", "tests"}
 
 
+def _disambiguate_colliding_titles(items: list[dict]) -> None:
+    """Append a folder context to document cards that share a display title.
+
+    The document title heuristic infers a heading/author name, so a stack of
+    resumes and cover letters all surface as "Gur Sannikov". The files are
+    genuinely distinct (unique source_path), so rather than re-running the
+    heuristic, disambiguate the *displayed* title in place with the parent
+    folder so the cards are tellable apart in the grid.
+    """
+    from collections import Counter
+    from pathlib import Path
+
+    counts = Counter(str(item.get("title") or "").strip().lower() for item in items)
+    for item in items:
+        title = str(item.get("title") or "").strip()
+        if not title or counts[title.lower()] < 2:
+            continue
+        source_path = str(item.get("source_path") or "")
+        if not source_path:
+            continue
+        path = Path(source_path)
+        # The filename (with its parent folder for context) is the on-disk
+        # discriminator for distinct files that infer the same title — including
+        # versioned files that share a folder, where the folder alone collides.
+        parent = path.parent.name
+        suffix = f"{parent}/{path.name}" if parent else path.name
+        item["title"] = f"{title} · {suffix}"
+
+
 def _unique_index_id(index_path: object, cat_dir: object) -> str:
     """Derive a collision-free browse id from an entry's index-file path."""
     if not index_path:
@@ -449,6 +478,9 @@ def browse_index_impl(
         if category == "integrations" and isinstance(entry.get("cli_tools"), list):
             item["cli_tools"] = entry["cli_tools"]
         items.append(item)
+
+    if category == "documents":
+        _disambiguate_colliding_titles(items)
 
     result: dict = {"items": items, "count": len(items)}
     if missing_category_status and not items:

--- a/src/mcp/augur_framework/tools/infrastructure/browse/index_common.py
+++ b/src/mcp/augur_framework/tools/infrastructure/browse/index_common.py
@@ -1,6 +1,9 @@
 """Shared constants and small value helpers for the browse index modules."""
 
-_BROWSE_LIMIT = 1000  # Max items per browse request to prevent MCP timeout
+# Max items per browse request to prevent MCP timeout. Sized above the largest
+# real category (tests ~1038) so dev-tier tabs aren't silently truncated; the
+# result still carries total_count/truncated as a safety net past this bound.
+_BROWSE_LIMIT = 1500
 
 _FILESYSTEM_BACKED_CATEGORIES = {
     "actions",

--- a/tests/dashboard/api/cli-config.test.ts
+++ b/tests/dashboard/api/cli-config.test.ts
@@ -172,6 +172,21 @@ describe("getCliAgentsConfig", () => {
     expect(module.isValidCli("codex")).toBe(true);
   });
 
+  it("finds _augur config even when AUGUR_VAULT_CONFIG_DIR cached the legacy path", async () => {
+    // Boot-race regression: AUGUR_VAULT_CONFIG_DIR is resolved ONCE at module
+    // load via existsSync. If the server booted before _augur/config existed
+    // (e.g. mid vault-sync during `aug dev build`), it cached the LEGACY path
+    // and every CLI chat failed with "Unknown CLI". The explicit _augur
+    // candidate must still resolve the file regardless of that cached choice.
+    const { fsCalls, module } = await loadCliConfig(MACHINE_AI_PATH, VAULT_CONFIG_DIR);
+
+    const agents = module.getCliAgentsConfig();
+
+    expect(fsCalls.readFileSync).toHaveBeenCalledWith(MACHINE_AI_PATH, "utf-8");
+    expect(agents.codex.cmd).toEqual(["codex", "exec"]);
+    expect(module.isValidCli("codex")).toBe(true);
+  });
+
   it("adds a direct Ollama CLI backed by the configured local model", async () => {
     const { module } = await loadCliConfigWithPrefs(
       [

--- a/tests/packages/augur-mcp/infrastructure/test_browse.py
+++ b/tests/packages/augur-mcp/infrastructure/test_browse.py
@@ -32,6 +32,26 @@ from src.mcp.augur_framework.tools.infrastructure.browse import (
     reveal_in_finder_impl,
 )
 
+def test_disambiguate_colliding_document_titles():
+    """Distinct files inferring the same title get a folder/filename suffix."""
+    from src.mcp.augur_framework.tools.infrastructure.browse.index import (
+        _disambiguate_colliding_titles,
+    )
+
+    items = [
+        {"title": "Gur Sannikov", "source_path": "/v/Downloads/resume_a.pdf"},
+        {"title": "Gur Sannikov", "source_path": "/v/Downloads/resume_b.pdf"},
+        {"title": "Unique Doc", "source_path": "/v/career/unique.md"},
+    ]
+    _disambiguate_colliding_titles(items)
+
+    titles = [i["title"] for i in items]
+    assert titles[0] == "Gur Sannikov · Downloads/resume_a.pdf"
+    assert titles[1] == "Gur Sannikov · Downloads/resume_b.pdf"
+    assert titles[2] == "Unique Doc"  # no collision -> untouched
+    assert len(set(titles)) == 3
+
+
 # =============================================================================
 # Fixtures
 # =============================================================================

--- a/tests/packages/augur-mcp/infrastructure/test_browse.py
+++ b/tests/packages/augur-mcp/infrastructure/test_browse.py
@@ -32,6 +32,7 @@ from src.mcp.augur_framework.tools.infrastructure.browse import (
     reveal_in_finder_impl,
 )
 
+
 def test_disambiguate_colliding_document_titles():
     """Distinct files inferring the same title get a folder/filename suffix."""
     from src.mcp.augur_framework.tools.infrastructure.browse.index import (


### PR DESCRIPTION
Generated full public release (v1.11.0) from the Augur source tree.

## Documentation updates
- **README Quick Start** restructured into **Fastest (AI client) / Manual (shell) / Verify** subsections with a TL;DR line.
- New **"Vibe coding with Augur"** README callout with a human-in-the-loop ⚠️ warning.
- New **`docs/vibe-coding.md`** — what vibe coding means here, how Augur helps, the safe loop, the warning, and links. Cross-linked from `getting-started.md` and `what-is-augur.md`.
- Install-docs guard (`aug onboard run` present, `corepack enable` confined to the contributor `<details>` block, no personal paths) still passes.

Plus the standard full-tree release payload (release scope: full).