### PR TITLE
fix(artifacts): don't let one corrupt sidecar 500 the artifacts list

### DIFF
--- a/src/lib/artifacts_sidecar.py
+++ b/src/lib/artifacts_sidecar.py
@@ -56,9 +56,7 @@ def read_sidecar(path: Path) -> Sidecar:
         if f.default is MISSING and f.default_factory is MISSING and name not in kwargs
     ]
     if missing:
-        raise ValueError(
-            f"artifact sidecar {path} is missing required field(s): {', '.join(missing)}"
-        )
+        raise ValueError(f"artifact sidecar {path} is missing required field(s): {', '.join(missing)}")
     return Sidecar(**kwargs)
 
 

--- a/src/lib/artifacts_sidecar.py
+++ b/src/lib/artifacts_sidecar.py
@@ -6,7 +6,7 @@ Pure helpers only: no MCP imports allowed here (the indexer CLI loads this in is
 from __future__ import annotations
 
 from collections.abc import Iterator
-from dataclasses import asdict, dataclass, field
+from dataclasses import MISSING, asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -45,8 +45,21 @@ def read_sidecar(path: Path) -> Sidecar:
     data = yaml.safe_load(body) or {}
     if not isinstance(data, dict):
         data = {}
-    known = set(Sidecar.__dataclass_fields__)
-    return Sidecar(**{k: v for k, v in data.items() if k in known})
+    fields = Sidecar.__dataclass_fields__
+    kwargs = {k: v for k, v in data.items() if k in fields}
+    # Fields with no default are required; an incomplete/corrupt sidecar would
+    # otherwise raise an opaque `TypeError: Sidecar.__init__() missing ...`.
+    # Raise a clear, diagnostic error instead so caller logs are actionable.
+    missing = [
+        name
+        for name, f in fields.items()
+        if f.default is MISSING and f.default_factory is MISSING and name not in kwargs
+    ]
+    if missing:
+        raise ValueError(
+            f"artifact sidecar {path} is missing required field(s): {', '.join(missing)}"
+        )
+    return Sidecar(**kwargs)
 
 
 def _sidecar_yaml_body(text: str) -> str:

--- a/src/mcp/augur_framework/tools/infrastructure/artifacts.py
+++ b/src/mcp/augur_framework/tools/infrastructure/artifacts.py
@@ -119,7 +119,13 @@ def artifacts_list_impl(*, docs_dir: Path) -> dict[str, Any]:
     """Return Browse-shape entries for every sidecar-backed HTML artifact."""
     entries: list[dict[str, Any]] = []
     for html_path, sidecar_path in _iter_artifact_files(docs_dir):
-        sc = read_sidecar(sidecar_path)
+        try:
+            sc = read_sidecar(sidecar_path)
+        except Exception:
+            # A corrupt/incomplete sidecar (missing a required field) must not
+            # 500 the whole list — skip it and keep building the catalog.
+            _log.warning("Skipping unreadable artifact sidecar: %s", sidecar_path)
+            continue
         entries.append(
             {
                 "slug": sc.slug,

--- a/tests/test_artifacts_tool.py
+++ b/tests/test_artifacts_tool.py
@@ -45,6 +45,23 @@ def test_write_and_read_sidecar_roundtrip(tmp_path: Path) -> None:
     assert loaded == sc
 
 
+def test_read_sidecar_raises_clear_error_when_required_field_missing(tmp_path: Path) -> None:
+    """A sidecar missing required fields raises a diagnostic ValueError naming them,
+    not an opaque ``TypeError: Sidecar.__init__() missing 4 required positional arguments``.
+    """
+    import pytest
+
+    sidecar_path = tmp_path / "incomplete.meta.yaml"
+    sidecar_path.write_text("---\nnote: incomplete\n---\n", encoding="utf-8")
+
+    with pytest.raises(ValueError) as exc:
+        read_sidecar(sidecar_path)
+    msg = str(exc.value)
+    assert str(sidecar_path) in msg
+    for field_name in ("slug", "title", "kind", "hub"):
+        assert field_name in msg
+
+
 def test_derive_title_from_html_title_tag() -> None:
     html = "<html><head><title>My Title</title></head><body></body></html>"
     assert derive_title(html, fallback="x.html") == "My Title"
@@ -96,6 +113,32 @@ def test_artifacts_list_skips_html_without_sidecar(tmp_path: Path) -> None:
     (tmp_path / "orphan.html").write_text("<html></html>", encoding="utf-8")
     result = artifacts_list_impl(docs_dir=tmp_path)
     assert result["artifacts"] == []
+
+
+def test_artifacts_list_skips_corrupt_sidecar(tmp_path: Path) -> None:
+    """A sidecar missing required fields must not 500 the whole list — it is skipped.
+
+    Regression: a single incomplete `.meta.yaml` crashed the artifacts list with
+    `TypeError: Sidecar.__init__() missing 4 required positional arguments`
+    (seen in production logs). One bad file must not take down the whole catalog.
+    """
+    bad_dir = tmp_path / "dev" / "artifacts"
+    bad_dir.mkdir(parents=True)
+    (bad_dir / "aaa-corrupt.html").write_text("<html>x</html>", encoding="utf-8")
+    # Sidecar present but missing required fields (slug/title/kind/hub).
+    (bad_dir / "aaa-corrupt.meta.yaml").write_text("note: incomplete\n", encoding="utf-8")
+
+    good_dir = tmp_path / "career" / "artifacts"
+    good_dir.mkdir(parents=True)
+    (good_dir / "good-one.html").write_text("<html><title>Good</title></html>", encoding="utf-8")
+    write_sidecar(
+        good_dir / "good-one.meta.yaml",
+        Sidecar(slug="good-one", title="Good", kind="saved", hub="career"),
+    )
+
+    result = artifacts_list_impl(docs_dir=tmp_path)
+
+    assert [e["slug"] for e in result["artifacts"]] == ["good-one"]
 
 
 def test_reindex_creates_sidecar_for_html_without_one(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Production MCP logs (`~/Library/Logs/Augur/augur_mcp.log`, 2026-06-23) showed artifact tools crashing repeatedly with:

```
TypeError: Sidecar.__init__() missing 4 required positional arguments: 'slug', 'title', 'kind', and 'hub'
```

at `src/lib/artifacts_sidecar.py:read_sidecar`.

## Root cause

Two layers conspire:

1. **`read_sidecar`** constructs `Sidecar(**{filtered data})` from whatever keys a `.meta.yaml` happens to contain. A corrupt or incomplete sidecar (missing any of the four required fields) raises an **opaque `TypeError`** that names dataclass internals, not the offending file.
2. **`artifacts_list_impl`** walks *every* sidecar-backed HTML with no guard, so a **single** bad `.meta.yaml` aborts the entire `artifacts-list` catalog. (`_collect_existing_slugs` already guards `read_sidecar` with try/except — `artifacts_list_impl` was the unguarded sibling.)

## Fix

- `read_sidecar` now raises a **clear `ValueError`** naming the missing required field(s) and the file path, so any caller's logs are actionable instead of cryptic.
- `artifacts_list_impl` **skips** an unreadable sidecar (`_log.warning` + `continue`) rather than 500-ing the whole list — degrading gracefully, matching the existing guard pattern.

## Verification

Reproduced the exact `TypeError` against a one-line incomplete sidecar, then confirmed it's gone:
- `artifacts_list_impl` returns the good artifact and skips the bad one (logs a warning).
- `read_sidecar` now raises `ValueError: artifact sidecar <path> is missing required field(s): slug, title, kind, hub`.

Added regression tests (`test_artifacts_list_skips_corrupt_sidecar`, `test_read_sidecar_raises_clear_error_when_required_field_missing`). **23 artifact tests pass; ruff clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)