### PR TITLE
fix(ingest): stamp artifact sidecar fields when /keep lands an HTML

### DIFF
--- a/project-brain/capabilities/skills/ingest/augur/tests/test_inbox_packet_consume.py
+++ b/project-brain/capabilities/skills/ingest/augur/tests/test_inbox_packet_consume.py
@@ -103,6 +103,80 @@ def test_consume_packet_moves_payload_writes_sidecar_and_archives(monkeypatch, t
     assert result.index_refreshed is True
 
 
+def test_consume_html_packet_stamps_artifact_sidecar_fields(monkeypatch, tmp_path: Path) -> None:
+    """Landing an .html packet writes a sidecar the artifacts catalog can read.
+
+    The artifacts scanner reads <stem>.meta.yaml next to <stem>.html. Without the
+    artifact fields (slug/title/kind/hub) read_sidecar raises and the file is
+    invisible in Browse. /keep reconcile must stamp them for HTML (Option A).
+    """
+    from skills.ingest.scripts.inbox_packet_consume import consume_packet
+    from skills.ingest.scripts.inbox_unified_models import (
+        InboxPacket,
+        InboxRouteProposal,
+        InboxVaultTarget,
+    )
+    from src.lib.artifacts_sidecar import read_sidecar
+
+    docs = tmp_path / "docs"
+    packet_dir = docs / "inbox" / "claude" / "packet"
+    packet_dir.mkdir(parents=True)
+    (packet_dir / "nvidia-prep-project-monterey.html").write_text(
+        "<html><head><title>NVIDIA Prep — Project Monterey DSE</title></head><body>x</body></html>",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "skills.ingest.scripts.inbox_packet_consume.refresh_notes_browse_index",
+        lambda vault_dir=None: type("Refresh", (), {"success": True})(),
+    )
+
+    packet = InboxPacket(
+        packet_id="packet",
+        source_id="claude-chat",
+        source_type="chat_mcp",
+        capture_mode="filesystem_mcp",
+        packet_dir=str(packet_dir),
+        title="NVIDIA Prep",
+        status="staged",
+        target_vault="personal",
+        original_filename="nvidia-prep-project-monterey.html",
+        payload_paths=["nvidia-prep-project-monterey.html"],
+        user_instruction="Keep this interview-prep HTML as a durable artifact",
+        content_hash="sha256:staged",
+        created_at="2026-06-23T15:15:28Z",
+    )
+    target = InboxVaultTarget("personal", "private", "Personal", str(tmp_path / "vault"), str(docs), True, True)
+    proposal = InboxRouteProposal(
+        packet_id="packet",
+        target_vault="personal",
+        target_domain="docs",
+        target_folder="career",
+        final_filename="nvidia-prep-project-monterey.html",
+        route_reason="agent session judgment (/keep reconcile)",
+        version_group="nvidia-prep-project-monterey",
+        status="ready",
+    )
+
+    result = consume_packet(packet=packet, target=target, proposal=proposal)
+
+    assert result.status == "success"
+    sidecar_path = docs / "career" / "nvidia-prep-project-monterey.meta.yaml"
+    sidecar = yaml.safe_load(sidecar_path.read_text(encoding="utf-8"))
+    # Ingest provenance is still present...
+    assert sidecar["source_id"] == "claude-chat"
+    assert sidecar["user_instruction"].startswith("Keep this")
+    # ...and the artifact fields are now stamped alongside it.
+    assert sidecar["slug"] == "nvidia-prep-project-monterey"
+    assert sidecar["title"] == "NVIDIA Prep — Project Monterey DSE"
+    assert sidecar["kind"] == "saved"
+    assert sidecar["hub"] == "career"
+    # The artifacts scanner can now read it without raising.
+    sc = read_sidecar(sidecar_path)
+    assert sc.slug == "nvidia-prep-project-monterey"
+    assert sc.title == "NVIDIA Prep — Project Monterey DSE"
+
+
 def test_consume_packet_fails_closed_when_proposal_not_ready(tmp_path: Path) -> None:
     from skills.ingest.scripts.inbox_packet_consume import consume_packet
     from skills.ingest.scripts.inbox_unified_models import InboxPacket, InboxRouteProposal, InboxVaultTarget

--- a/project-brain/capabilities/skills/ingest/scripts/inbox_packet_consume.py
+++ b/project-brain/capabilities/skills/ingest/scripts/inbox_packet_consume.py
@@ -116,10 +116,34 @@ def _write_sidecar(
         "created_at": packet.created_at,
         "consumed_at": _now_iso(),
     }
+    # The artifacts catalog scans <stem>.meta.yaml next to every <stem>.html.
+    # When we land an HTML payload, stamp the artifact-sidecar fields alongside
+    # the ingest provenance so read_sidecar can parse it; otherwise it raises
+    # (missing slug/title/kind/hub) and the file is invisible in Browse. The two
+    # schemas coexist in one doc — each reader takes only its known keys.
+    if final_path.suffix.lower() == ".html":
+        payload.update(_artifact_sidecar_fields(final_path, proposal))
     sidecar_path.write_text(
         yaml.safe_dump(payload, sort_keys=False, default_flow_style=False),
         encoding="utf-8",
     )
+
+
+def _artifact_sidecar_fields(final_path: Path, proposal: InboxRouteProposal) -> dict[str, str]:
+    """Artifact-sidecar fields for a landed HTML payload (slug/title/kind/hub)."""
+    from src.mcp.augur_framework.tools.infrastructure.artifacts import derive_slug, derive_title
+
+    try:
+        title = derive_title(final_path.read_text(encoding="utf-8", errors="replace"), fallback=final_path.name)
+    except OSError:
+        title = final_path.stem
+    hub = (proposal.target_folder or "").split("/", 1)[0] or "uncategorized"
+    return {
+        "slug": derive_slug(filename=final_path.name),
+        "title": title,
+        "kind": "saved",
+        "hub": hub,
+    }
 
 
 def _mark_packet_consumed(packet: InboxPacket) -> None:


### PR DESCRIPTION
## Problem (root cause of the #52 crash)

`/keep reconcile` (`inbox_packet_consume._sidecar_path`) writes `<stem>.meta.yaml` next to the landed file — **the same sidecar filename the artifacts catalog scans** (`sidecar_path_for_html`). But for HTML payloads it wrote only the *ingest* schema (`source_id`, `target_vault`, `content_hash`, …) with **none** of the artifact fields (`slug`/`title`/`kind`/`hub`).

Result: `read_sidecar` raised on those files. Real example on the author's machine — two NVIDIA interview-prep HTMLs landed by `/keep` on 2026-06-23 produced exactly the `TypeError` seen in production logs, and the artifacts catalog couldn't list them. #52 made the artifact side *tolerate* this (skip + warn); this PR fixes the **upstream cause** so the sidecar is valid in the first place and the kept HTML actually surfaces in Browse.

## Fix (Option A)

When the landed payload is `.html`, stamp the artifact fields into the sidecar alongside the ingest provenance:
- `slug` ← `derive_slug(filename)`, `title` ← `derive_title(html)` (reused from the artifacts system, so values match `artifacts-reindex`)
- `kind: saved`, `hub` ← first segment of the target folder

The two schemas coexist in one YAML doc — each reader takes only its known keys. **Scoped to `.html`** (the only type `iter_artifact_files` picks up); `.pptx`/`.pdf`/`.docx`/`.md` packets are unchanged.

## Verification

- New test: consumed HTML sidecar carries **both** schemas and is `read_sidecar`-parseable (`slug`/`title`/`kind`/`hub` correct).
- Existing `.pptx` test still passes → non-HTML untouched.
- **End-to-end:** consume an HTML packet → resulting sidecar → real `artifacts_list_impl` surfaces it as `career / NVIDIA Prep — Project Monterey DSE / nvidia-prep-monterey`.
- 9 ingest-consume tests pass; Black + ruff clean.

Note: repairing the two *already-landed* malformed sidecars in the author's `~/Documents` is separate (and currently blocked by a local macOS Privacy/TCC permission on that folder); this PR prevents recurrence for future `/keep` HTML captures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)